### PR TITLE
Fix player sometimes spawn in the wrong location.

### DIFF
--- a/player.py
+++ b/player.py
@@ -6,7 +6,8 @@ import pygame as pg
 class Player:
     def __init__(self, engine):
         self.engine = engine
-        self.thing = engine.wad_data.things[0]
+        # Player 1 start thing has a type equal to 1
+        self.thing = next((thing for thing in engine.wad_data.things if thing.type == 1), None)
         self.pos = self.thing.pos
         self.angle = self.thing.angle
         self.DIAG_MOVE_CORR = 1 / math.sqrt(2)


### PR DESCRIPTION
The player spawn is incorrectly determined as the thing 0. It should be the thing where the type equals 1. Type 1 means Player 1 start : 

![Capture d’écran du 2024-12-04 11-35-51](https://github.com/user-attachments/assets/e3f08950-2f29-4a56-b37d-8a4e7d77abef)
You can see here: https://doomwiki.org/wiki/Thing_types

This caused the player to, in some maps, spawn in the wrong location.

This fix ensures that the player spawn is chosen based on the type.