### PR TITLE
Fix sometimes drawing a wall with a flat texture

### DIFF
--- a/asset_data.py
+++ b/asset_data.py
@@ -134,17 +134,17 @@ class AssetData:
         if self.get_lump_index('TEXTURE2'):
             texture_maps += self.load_texture_maps(texture_lump_name='TEXTURE2')
 
-        self.textures = {
+        self.wall_textures = {
             tex_map.name: Texture(self, tex_map).image for tex_map in texture_maps
         }
         # flat textures
-        self.textures |= self.get_flats()
+        self.flat_textures = self.get_flats()
 
         # --------------------------------------------------------------------------- #
         # sky
         self.sky_id = 'F_SKY1'
         self.sky_tex_name = 'SKY1'
-        self.sky_tex = self.textures[self.sky_tex_name]
+        self.sky_tex = self.wall_textures[self.sky_tex_name]
         # --------------------------------------------------------------------------- #
 
     def get_flats(self, start_marker='F_START', end_marker='F_END'):

--- a/seg_handler.py
+++ b/seg_handler.py
@@ -11,7 +11,7 @@ class SegHandler:
         self.player = engine.player
         self.framebuffer = self.engine.framebuffer
         self.wall_textures = self.wad_data.asset_data.wall_textures
-        self.flat_textures = self.wad_data.asset_data.flat_textures
+        # self.flat_textures = self.wad_data.asset_data.flat_textures
         self.sky_id = self.wad_data.asset_data.sky_id
         #
         self.seg = None

--- a/seg_handler.py
+++ b/seg_handler.py
@@ -10,7 +10,8 @@ class SegHandler:
         self.wad_data = engine.wad_data
         self.player = engine.player
         self.framebuffer = self.engine.framebuffer
-        self.textures = self.wad_data.asset_data.textures
+        self.wall_textures = self.wad_data.asset_data.wall_textures
+        self.flat_textures = self.wad_data.asset_data.flat_textures
         self.sky_id = self.wad_data.asset_data.sky_id
         #
         self.seg = None
@@ -94,7 +95,7 @@ class SegHandler:
 
         # -------------------------------------------------------------------------- #
         # determine how the wall texture are vertically aligned
-        wall_texture = self.textures[wall_texture_id]
+        wall_texture = self.wall_textures[wall_texture_id]
         if line.flags & self.wad_data.LINEDEF_FLAGS['DONT_PEG_BOTTOM']:
             v_top = front_sector.floor_height + wall_texture.shape[1]
             middle_tex_alt = v_top - self.player.height
@@ -216,7 +217,7 @@ class SegHandler:
 
         # determine how the wall textures are vertically aligned
         if b_draw_upper_wall:
-            upper_wall_texture = self.textures[side.upper_texture]
+            upper_wall_texture = self.wall_textures[side.upper_texture]
 
             if line.flags & self.wad_data.LINEDEF_FLAGS['DONT_PEG_TOP']:
                 upper_tex_alt = world_front_z1
@@ -226,7 +227,7 @@ class SegHandler:
             upper_tex_alt += side.y_offset
 
         if b_draw_lower_wall:
-            lower_wall_texture = self.textures[side.lower_texture]
+            lower_wall_texture = self.wall_textures[side.lower_texture]
 
             if line.flags & self.wad_data.LINEDEF_FLAGS['DONT_PEG_BOTTOM']:
                 lower_tex_alt = world_front_z1

--- a/view_renderer.py
+++ b/view_renderer.py
@@ -12,7 +12,8 @@ class ViewRenderer:
         self.asset_data = engine.wad_data.asset_data
         self.palette = self.asset_data.palette
         self.sprites = self.asset_data.sprites
-        self.textures = self.asset_data.textures
+        self.wall_textures = self.asset_data.wall_textures
+        self.flat_textures = self.asset_data.flat_textures
         self.player = engine.player
         self.screen = engine.screen
         self.framebuffer = engine.framebuffer
@@ -65,7 +66,7 @@ class ViewRenderer:
                 self.draw_wall_col(self.framebuffer, self.sky_tex, tex_column, x, y1, y2,
                                    self.sky_tex_alt, self.sky_inv_scale, light_level=1.0)
             else:
-                flat_tex = self.textures[tex_id]
+                flat_tex = self.flat_textures[tex_id]
 
                 self.draw_flat_col(self.framebuffer, flat_tex,
                                    x, y1, y2, light_level, world_z,

--- a/view_renderer.py
+++ b/view_renderer.py
@@ -12,7 +12,7 @@ class ViewRenderer:
         self.asset_data = engine.wad_data.asset_data
         self.palette = self.asset_data.palette
         self.sprites = self.asset_data.sprites
-        self.wall_textures = self.asset_data.wall_textures
+        # self.wall_textures = self.asset_data.wall_textures
         self.flat_textures = self.asset_data.flat_textures
         self.player = engine.player
         self.screen = engine.screen


### PR DESCRIPTION
Sometimes, flat texture and wall texture have the same name, example:

Wall texture:
![Capture d’écran du 2024-12-04 14-48-00](https://github.com/user-attachments/assets/ab57442f-18c6-40d8-9ddd-ca350b0864f8)
Flat texture:
![Capture d’écran du 2024-12-04 14-48-12](https://github.com/user-attachments/assets/3e403842-dc2f-49e3-8e78-b4e8208d93b2)

The problem in the code is in [asset_data.py](https://github.com/StanislavPetrovV/DOOM-Level-Viewer/blob/main/asset_data.py#L137) line 137 to 141.

The `textures` dictionary is populated with wall textures first, and flat textures later. But if a flat texture have the same name of a wall texture it gets override.

So sometimes, when drawing a wall, it use a flat texture.

This PR fixes that by splitting the `textures` dictionary into `wall_textures` and `flat_textures` dictionaries.

### Example in e1m1 doom1.wad, wrong texture for stairs

Before PR (incorrect texture)
![Capture d’écran du 2024-12-04 14-40-10](https://github.com/user-attachments/assets/dca63d38-210e-456d-8a37-beab38e2caf1)

After PR (correct texture)
![Capture d’écran du 2024-12-04 14-39-47](https://github.com/user-attachments/assets/bf0d5307-f9db-4540-b18c-af7ff391b9ea)

Reference (using SLADE)
![Capture d’écran du 2024-12-04 14-40-35](https://github.com/user-attachments/assets/e290b275-2756-410a-9804-9cdf5925b254)

